### PR TITLE
Add Expense Categories to BudgetBuddy

### DIFF
--- a/BudgetBuddy/Home/Views/AddView.swift
+++ b/BudgetBuddy/Home/Views/AddView.swift
@@ -16,10 +16,8 @@ struct AddView: View {
     private var disableForm: Bool { name.isEmpty || amount == nil }
 
     @State private var name = ""
-    @State private var type = "Personal"
+    @State private var type: ExpenseType = .food
     @State private var amount: Double? = nil
-
-    let types = ["Business", "Personal"]
 
     var body: some View {
         NavigationStack {
@@ -31,9 +29,9 @@ struct AddView: View {
                 }
                 Section("Expense details") {
                     Picker("Type", selection: $type) {
-                        ForEach(types, id: \.self) {
-                            Text($0)
-                        }
+                        ForEach(ExpenseType.allCases, id: \.self) { type in
+                                Text(type.displayName).tag(type)
+                            }
                     }
                     HStack {
                         Text("$")

--- a/BudgetBuddy/Home/Views/AddView.swift
+++ b/BudgetBuddy/Home/Views/AddView.swift
@@ -28,9 +28,9 @@ struct AddView: View {
                         .textInputAutocapitalization(.never)
                 }
                 Section("Expense details") {
-                    Picker("Type", selection: $type) {
+                    Picker("Category", selection: $type) {
                         ForEach(ExpenseType.allCases, id: \.self) { type in
-                                Text(type.displayName).tag(type)
+                            Text(type.displayIcon + " " + type.displayName).tag(type)
                             }
                     }
                     HStack {

--- a/BudgetBuddy/Home/Views/ExpenseView.swift
+++ b/BudgetBuddy/Home/Views/ExpenseView.swift
@@ -58,6 +58,7 @@ extension ExpenseView {
             NoExpensesView(expenseType: expenseType)
         } else {
             listView
+    
         }
     }
     

--- a/BudgetBuddy/Home/Views/ExpenseView.swift
+++ b/BudgetBuddy/Home/Views/ExpenseView.swift
@@ -11,25 +11,28 @@ import SwiftUI
 struct ExpenseView: View {
     @Environment(\.modelContext) var modelContext
     @Query var expenses: [ExpenseItem]
-    var expenseType: String
+    var expenseType: ExpenseType? = nil
 
     var body: some View {
         conditionalView
     }
 
-    init(expenseType: String, sortOrder: [SortDescriptor<ExpenseItem>]) {
-        _expenses = Query(
-            filter: #Predicate<ExpenseItem> { expense in
-                if expenseType == "" {
-                    return true
-                } else {
-                    return (expense.type == expenseType)
-                }
-            },
-            sort: sortOrder
-        )
+    init(expenseType: ExpenseType?, sortOrder: [SortDescriptor<ExpenseItem>]) {
+        if let expenseType {
+            _expenses = Query(
+                filter: #Predicate<ExpenseItem> { expense in
+                    expense.typeRaw == expenseType.rawValue
+                },
+                sort: sortOrder
+            )
+        } else {
+            _expenses = Query(
+                sort: sortOrder
+            )
+        }
         self.expenseType = expenseType
     }
+
 
     func removeItems(at offsets: IndexSet) {
         for offset in offsets {
@@ -41,10 +44,10 @@ struct ExpenseView: View {
 
 #Preview {
     ExpenseView(
-        expenseType: "Personal",
+        expenseType: nil,
         sortOrder: [SortDescriptor(\ExpenseItem.name)]
     )
-    .modelContainer(for: ExpenseItem.self)
+    .modelContainer(PreviewSampleData.sampleExpenses())
 }
 
 extension ExpenseView {
@@ -68,7 +71,10 @@ extension ExpenseView {
                         VStack(alignment: .leading) {
                             Text(expense.name)
                                 .font(.headline)
-                            Text(expense.type)
+                            HStack {
+                                Text(expense.type.displayIcon)
+                                Text(expense.type.displayName)
+                            }
                         }
                     }
                     Spacer()
@@ -81,7 +87,7 @@ extension ExpenseView {
                 }
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel("\(expense.name), costs \(expense.amount)")
-                .accessibilityHint(expense.type)
+                .accessibilityHint(expense.type.displayName)
             }
             .onDelete(perform: removeItems)
         }

--- a/BudgetBuddy/Home/Views/HomeView.swift
+++ b/BudgetBuddy/Home/Views/HomeView.swift
@@ -24,7 +24,12 @@ struct HomeView: View {
 
     var body: some View {
         NavigationStack {
-            conditionalView
+            VStack(spacing: 0){
+                conditionalView
+            }
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    Color.clear.frame(height: 25)
+                }
                 .toolbar {
                     ToolbarItemGroup(placement: .topBarLeading) {
                         if !noExpensesAdded {
@@ -39,6 +44,7 @@ struct HomeView: View {
                     }
                 }
                 .navigationTitle("BudgetBuddy")
+                
         }
     }
 }
@@ -59,6 +65,7 @@ extension HomeView {
                 expenseType: expenseTypeShowed,
                 sortOrder: sortOrder
             )
+            
       }
     }
 
@@ -76,11 +83,26 @@ extension HomeView {
                 "slider.horizontal.3"
         ) {
             Picker("Filter", selection: $expenseTypeShowed) {
-                Text("Show only food expenses")
+                Text("Food expenses")
                     .tag(ExpenseType.food as ExpenseType?)
 
-                Text("Show only social expenses")
+                Text("Social expenses")
                     .tag(ExpenseType.social as ExpenseType?)
+                
+                Text("Transport expenses")
+                    .tag(ExpenseType.transport as ExpenseType?)
+
+                Text("Culture expenses")
+                    .tag(ExpenseType.culture as ExpenseType?)
+                
+                Text("Household expenses")
+                    .tag(ExpenseType.household as ExpenseType?)
+
+                Text("Education expenses")
+                    .tag(ExpenseType.education as ExpenseType?)
+                
+                Text("Gift expenses")
+                    .tag(ExpenseType.gift as ExpenseType?)
 
                 Text("Remove filters")
                     .tag(nil as ExpenseType?)

--- a/BudgetBuddy/Home/Views/HomeView.swift
+++ b/BudgetBuddy/Home/Views/HomeView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct HomeView: View {
     @Environment(\.modelContext) var modelContext
     @Query var expenses: [ExpenseItem]
-    @State private var expenseTypeShowed = ""
+    @State private var expenseTypeShowed: ExpenseType? = nil
     
     private var noExpensesAdded: Bool { expenses.isEmpty }
 
@@ -45,6 +45,7 @@ struct HomeView: View {
 
 #Preview {
     HomeView()
+        .modelContainer(PreviewSampleData.sampleExpenses())
 }
 
 extension HomeView {
@@ -75,14 +76,14 @@ extension HomeView {
                 "slider.horizontal.3"
         ) {
             Picker("Filter", selection: $expenseTypeShowed) {
-                Text("Show only Personal expenses")
-                    .tag("Personal")
+                Text("Show only food expenses")
+                    .tag(ExpenseType.food as ExpenseType?)
 
-                Text("Show only Business expenses")
-                    .tag("Business")
+                Text("Show only social expenses")
+                    .tag(ExpenseType.social as ExpenseType?)
 
                 Text("Remove filters")
-                    .tag("")
+                    .tag(nil as ExpenseType?)
             }
         }
     }

--- a/BudgetBuddy/Home/Views/NoExpensesView.swift
+++ b/BudgetBuddy/Home/Views/NoExpensesView.swift
@@ -33,7 +33,7 @@ private enum Layout {
         static let height: CGFloat = 55
         static let cornerRadius: CGFloat = 10
         static let internalPadding: CGFloat = 30
-        static let externalPadding: CGFloat = 40
+        static let externalPadding: CGFloat = 30
     }
 }
 

--- a/BudgetBuddy/Home/Views/NoExpensesView.swift
+++ b/BudgetBuddy/Home/Views/NoExpensesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct NoExpensesView: View {
-    var expenseType: String = ""
+    var expenseType: ExpenseType? = nil
 
     var body: some View {
         VStack(spacing: Layout.spacing) {
@@ -21,7 +21,7 @@ struct NoExpensesView: View {
 }
 
 #Preview {
-    NoExpensesView()
+    NoExpensesView(expenseType: .culture)
 }
 
 private enum Layout {
@@ -38,24 +38,34 @@ private enum Layout {
 }
 
 extension NoExpensesView {
+    
     private var title: some View {
-        Text(
-            expenseType.isEmpty
-                ? "No expenses yet!"
-                : "No \(expenseType.lowercased()) expenses yet!"
-        )
-        .font(.title)
-        .fontWeight(.semibold)
-        .multilineTextAlignment(.center)
+        Text(titleText)
+            .font(.title)
+            .fontWeight(.semibold)
+            .multilineTextAlignment(.center)
+    }
+    
+    private var titleText: String {
+        if let expenseType = self.expenseType {
+            "No \(expenseType.displayName.lowercased()) expenses yet!"
+        } else {
+            "No expenses yet!"
+        }
     }
     
     private var description: some View {
-        Text(
-            expenseType.isEmpty
-                ? "Add your first expense below"
-                : "Add your first \(expenseType.lowercased()) expense below"
-        )
+        Text(descriptionText)
         .padding(.bottom, Layout.bottomPadding)
+        .multilineTextAlignment(.center)
+    }
+    
+    private var descriptionText: String  {
+        if let expenseType = self.expenseType {
+            "Add your first \(expenseType.displayName.lowercased()) expense below or change the filters applied"
+        } else {
+            "Add your first expense below"
+        }
     }
     
     private var addExpenseButton: some View {

--- a/BudgetBuddy/Models/ExpenseItem.swift
+++ b/BudgetBuddy/Models/ExpenseItem.swift
@@ -12,20 +12,25 @@ import SwiftData
 class ExpenseItem: Identifiable, Equatable {
     var id = UUID()
     var name: String
-    var type: ExpenseType
+    var typeRaw: String
     var amount: Double
     var date: Date
+    
+    var type: ExpenseType {
+            get { ExpenseType(rawValue: typeRaw) ?? .food }
+            set { typeRaw = newValue.rawValue }
+        }
     
     init(id: UUID = UUID(), name: String, type: ExpenseType, amount: Double, date: Date = .now) {
         self.id = id
         self.name = name
-        self.type = type
+        self.typeRaw = type.rawValue
         self.amount = amount
         self.date = date
     }
 }
 
-enum ExpenseType {
+enum ExpenseType: String, Codable, CaseIterable {
     case food
     case social
     case transport

--- a/BudgetBuddy/Support/ExpenseTypeDisplay.swift
+++ b/BudgetBuddy/Support/ExpenseTypeDisplay.swift
@@ -1,0 +1,34 @@
+//
+//  ExpenseTypeDisplay.swift
+//  BudgetBuddy
+//
+//  Created by Francisco Manuel Gallegos Luque on 22/09/2025.
+//
+
+import Foundation
+
+extension ExpenseType {
+    var displayName: String {
+        switch self {
+        case .food: return "Food"
+        case .social: return "Social"
+        case .transport: return "Transport"
+        case .education: return "Education"
+        case .gift: return "Gift"
+        case .culture: return "Culture"
+        case .household: return "Household"
+        }
+    }
+    
+    var displayIcon: String {
+        switch self {
+        case .food: return "🍝"
+        case .social: return "🎊"
+        case .transport: return "🚌"
+        case .education: return "📚"
+        case .gift: return "🎁"
+        case .culture: return "🪉"
+        case .household: return "🪑"
+        }
+    }
+}

--- a/BudgetBuddy/Support/PreviewSampleData.swift
+++ b/BudgetBuddy/Support/PreviewSampleData.swift
@@ -1,0 +1,49 @@
+//
+//  PreviewSampleData.swift
+//  BudgetBuddy
+//
+//  Created by Francisco Manuel Gallegos Luque on 22/09/2025.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+struct PreviewSampleData {
+    static func sampleExpenses() -> ModelContainer {
+        do {
+            let container = try ModelContainer(
+                for: ExpenseItem.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+            )
+            let mockExpenses = [
+                ExpenseItem(
+                    name: "Coffee",
+                    type: .food,
+                    amount: 3.50,
+                    date: .now
+                ),
+                ExpenseItem(
+                    name: "Concert Ticket",
+                    type: .culture,
+                    amount: 50,
+                    date: .now
+                ),
+                ExpenseItem(
+                    name: "Taxi",
+                    type: .transport,
+                    amount: 12,
+                    date: .now
+                ),
+            ]
+
+            for mockExpense in mockExpenses {
+                container.mainContext.insert(mockExpense)
+            }
+
+            return container
+        } catch {
+            fatalError("Failed to create container")
+        }
+    }
+}


### PR DESCRIPTION
- Added ExpenseType enum for expense categories (Food, Social, Transport, etc.)
- Updated ExpenseItem model to include a category
- Updated Add Expense view to allow selecting a category
- Updated filtering and display logic to use categories


